### PR TITLE
Include topic config properties in describe topic command

### DIFF
--- a/zoe-cli/src/commands/main.kt
+++ b/zoe-cli/src/commands/main.kt
@@ -71,6 +71,7 @@ class ZoeCommandLine : CliktCommand(name = "zoe") {
             .choice(
                 "raw" to Format.Raw,
                 "json" to Format.Json,
+                "json-p" to Format.JsonPretty,
                 "table" to Format.Table
             )
             .default(Format.Raw)

--- a/zoe-cli/src/config/config.kt
+++ b/zoe-cli/src/config/config.kt
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.databind.JsonNode
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.toList
-import java.time.Duration
 
 data class EnvConfig(
     val runners: RunnersSection,
@@ -156,11 +155,12 @@ enum class RunnerName(@JsonValue val code: String) {
 }
 
 enum class Format {
-    Json, Raw, Table;
+    Json, JsonPretty, Raw, Table;
 
     fun format(content: JsonNode, foreach: (String) -> Unit) = when (this) {
         Raw -> foreach(content.toString())
         Json -> foreach(content.toString())
+        JsonPretty -> foreach(content.toPrettyString())
         Table -> foreach(content.toPrettyPrintedTable())
     }
 

--- a/zoe-cli/test/com/adevinta/oss/zoe/cli/mainTests.kt
+++ b/zoe-cli/test/com/adevinta/oss/zoe/cli/mainTests.kt
@@ -1,9 +1,13 @@
 package com.adevinta.oss.zoe.cli
 
+import com.adevinta.oss.zoe.core.functions.TopicDescription
 import com.adevinta.oss.zoe.core.utils.parseJson
 import com.adevinta.oss.zoe.core.utils.toJsonNode
 import io.kotest.core.spec.style.ExpectSpec
+import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.maps.shouldNotBeEmpty
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -25,6 +29,15 @@ class MainTest : ExpectSpec({
             zoe("topics", "create", topic) { it.stdout shouldBe """{"done": true}""".toJsonNode() }
 
             zoe("topics", "list") { it.stdout?.parseJson<List<String>>()?.shouldContain(topic) }
+
+            zoe("topics", "describe", topic) {
+                it.stdout?.parseJson<TopicDescription>()?.should { topicDescription ->
+                    topicDescription.topic.shouldBe(topic)
+                    topicDescription.partitions.shouldBe(listOf(0))
+                    topicDescription.internal.shouldBeFalse()
+                    topicDescription.config.shouldNotBeEmpty()
+                }
+            }
 
             context("creating an avro schema") {
                 zoe(


### PR DESCRIPTION
When describing a topic in _zoe_ it would be useful to also display the config properties of it. 

This PR introduces this feature by extending the `TopicDescription ` class with the config properties as map. 

When describing a topic the current implementation in _zoe_ just loads the descriptions of all topics and then just returns the description of the requested topic. This remains the same with this PR. I tested it on a local kafka cluster with 11 topics and there was no significant change in performance, so i think its ok :). 

I also adjusted the cli format method when requesting output format `json`. It now pretty-prints the json as i guess this is the desired result.

Example result of a topic description now when calling:

`zoe -c local -o json  topics describe someTopic`

Result:

```{
  "topic" : "someTopic",
  "internal" : false,
  "partitions" : [ 0, 1 ],
  "config" : {
    "cleanup.policy" : "compact",
    "compression.type" : "producer",
    "delete.retention.ms" : "100",
    "file.delete.delay.ms" : "60000",
    "flush.messages" : "9223372036854775807",
    "flush.ms" : "9223372036854775807",
    "index.interval.bytes" : "4096",
    "max.message.bytes" : "1000012",
    "message.downconversion.enable" : "true",
    "message.format.version" : "2.1-IV2",
    "message.timestamp.difference.max.ms" : "9223372036854775807",
    "message.timestamp.type" : "CreateTime",
    "min.cleanable.dirty.ratio" : "0.01",
    "min.compaction.lag.ms" : "100",
    "min.insync.replicas" : "1",
    "preallocate" : "false",
    "retention.bytes" : "-1",
    "retention.ms" : "604800000",
    "segment.bytes" : "1073741824",
    "segment.index.bytes" : "10485760",
    "segment.jitter.ms" : "0",
    "segment.ms" : "604800000",
    "unclean.leader.election.enable" : "false"
  }
}
```

If something is missing or needs to be adjusted, just let me know. i will update the PR. 

Also thanks for the work on _zoe_ 👌 !  
Working now for a week with it and have not looked back to the original kafka-cli since then (except to see the configs of a specific topic) 