### PR TITLE
Add ability to filter on headers and other records metadata

### DIFF
--- a/zoe-cli/src/utils/messages.kt
+++ b/zoe-cli/src/utils/messages.kt
@@ -28,7 +28,7 @@ object HelpMessages {
 
     fun howToInitZoeLambda() = listOf(
         "It looks like the zoe lambda function is not deployed in your AWS environment. " +
-            "Have you you run: `zoe -e <env> lambda deploy`?",
+            "Did you run: `zoe -e <env> lambda deploy`?",
         "You may also need to configure the lambda runner in your zoe config. " +
             "Check out: ${DocUrl}/advanced/runners/lambda"
     )

--- a/zoe-core/src/functions/produce.kt
+++ b/zoe-core/src/functions/produce.kt
@@ -26,7 +26,7 @@ import org.apache.kafka.clients.producer.RecordMetadata
  * Lambda function to producer a bunch of records into kafka
  */
 val produce = zoeFunction<ProduceConfig, ProduceResponse>(name = "produce") { config ->
-    val jsonSearch = config.jsonQueryDialect.getImplementation()
+    val jsonSearch = config.jsonQueryDialect.createInstance()
 
     val keyPath = config.keyPath?.also(jsonSearch::validate)
     val valuePath = config.valuePath?.also(jsonSearch::validate)
@@ -38,9 +38,9 @@ val produce = zoeFunction<ProduceConfig, ProduceResponse>(name = "produce") { co
         ProducerRecord<Any?, Any?>(
             config.topic,
             null,
-            tsPath?.let { jsonSearch.search(row, it) }?.longValue(),
-            keyPath?.let { jsonSearch.search(row, it) }?.textValue() ?: uuid(),
-            dejsonifier.dejsonify(valuePath?.let { jsonSearch.search(row, it) } ?: row)
+            tsPath?.let { jsonSearch.query(row, it) }?.longValue(),
+            keyPath?.let { jsonSearch.query(row, it) }?.textValue() ?: uuid(),
+            dejsonifier.dejsonify(valuePath?.let { jsonSearch.query(row, it) } ?: row)
         )
     }
 

--- a/zoe-core/src/utils/json.kt
+++ b/zoe-core/src/utils/json.kt
@@ -12,7 +12,7 @@ import java.util.concurrent.ConcurrentHashMap
 
 interface JsonSearch {
     fun validate(expr: String)
-    fun search(obj: JsonNode, expr: String): JsonNode
+    fun query(obj: JsonNode, expr: String): JsonNode
 }
 
 class JmespathImpl : JsonSearch {
@@ -26,7 +26,7 @@ class JmespathImpl : JsonSearch {
         }
     }
 
-    override fun search(obj: JsonNode, expr: String): JsonNode {
+    override fun query(obj: JsonNode, expr: String): JsonNode {
         val compiled = getOrCompile(expr)
         return compiled.search(obj)
     }
@@ -47,7 +47,7 @@ class JqImpl : JsonSearch {
         }
     }
 
-    override fun search(obj: JsonNode, expr: String): JsonNode {
+    override fun query(obj: JsonNode, expr: String): JsonNode {
         val compiled = getOrCompile(expr)
         val results = ArrayList<JsonNode>().apply {
             compiled.apply(scope, obj) { add(it) }
@@ -63,4 +63,4 @@ class JqImpl : JsonSearch {
 }
 
 fun JsonSearch.match(obj: JsonNode, filters: List<String>): Boolean =
-    filters.all { expr -> search(obj, expr).asBoolean() }
+    filters.all { expr -> query(obj, expr).asBoolean() }

--- a/zoe-service/src/service.kt
+++ b/zoe-service/src/service.kt
@@ -87,6 +87,7 @@ class ZoeService(
         topic: TopicAliasOrRealName,
         from: ConsumeFrom,
         filters: List<String>,
+        metadataFilters: List<String>,
         query: String?,
         parallelism: Int,
         numberOfRecordsPerBatch: Int,
@@ -101,7 +102,9 @@ class ZoeService(
         val completedProps = clusterConfig.getCompletedProps()
 
         val resolvedFilters = filters.map { resolveExpression(it) }
+        val resolvedMetaFilters = metadataFilters.map { resolveExpression(it) }
         val resolvedQuery = query?.let { resolveExpression(it) }
+
 
         val partitionGroups: Collection<List<ConsumptionRange>> =
             determineConsumptionRange(
@@ -116,6 +119,7 @@ class ZoeService(
                 props = completedProps,
                 topic = topicName,
                 filter = resolvedFilters,
+                filterMeta = resolvedMetaFilters,
                 query = resolvedQuery,
                 range = rangeGroup,
                 recordsPerBatch = numberOfRecordsPerBatch,
@@ -370,6 +374,7 @@ class ZoeService(
         props: Map<String, String>,
         topic: String,
         filter: List<String>,
+        filterMeta: List<String>,
         query: String?,
         range: List<ConsumptionRange>,
         recordsPerBatch: Int,
@@ -389,6 +394,7 @@ class ZoeService(
                 ),
                 props = props,
                 filter = filter,
+                filterMeta = filterMeta,
                 query = query,
                 timeoutMs = timeoutPerBatch,
                 numberOfRecords = recordsPerBatch,

--- a/zoe-service/test/simulator/simulator.kt
+++ b/zoe-service/test/simulator/simulator.kt
@@ -15,6 +15,9 @@ import com.adevinta.oss.zoe.service.runners.ZoeRunner
 import com.fasterxml.jackson.databind.JsonNode
 import kotlin.math.min
 
+/**
+ * de
+ */
 class ZoeRunnerSimulator(val state: RunnerState) : ZoeRunner {
 
     override val name: String = "simulator"
@@ -77,7 +80,7 @@ class ZoeRunnerSimulator(val state: RunnerState) : ZoeRunner {
                         timestamp = it.timestamp,
                         partition = it.partition,
                         topic = topic.name,
-                        formatted = it.content
+                        content = it.content
                     )
                 }
                 .toList(),


### PR DESCRIPTION
This PR adds 2 options in the CLI to the `topics consume` command:
- `--filter-meta` that allows users to express jq / jmespath filters on headers, partitions, keys and other record metadata.
- `--with-meta` that prints the consumed records with their metadata (offset, partition, headers, etc.)

Related issue: https://github.com/adevinta/zoe/issues/3