### PR TITLE
[Topic create] add ability to inject extra config

### DIFF
--- a/zoe-cli/build.gradle.kts
+++ b/zoe-cli/build.gradle.kts
@@ -189,7 +189,7 @@ dependencies {
 
     implementation("org.koin:koin-core:2.0.1")
     implementation("com.jakewharton.picnic:picnic:0.3.1")
-    implementation("com.github.ajalt:clikt:2.5.0")
+    implementation("com.github.ajalt:clikt:2.8.0")
     implementation("com.github.ajalt:mordant:1.2.1")
     implementation("org.slf4j:slf4j-log4j12:1.7.30")
     implementation("log4j:log4j:1.2.17")

--- a/zoe-core/src/functions/admin.kt
+++ b/zoe-core/src/functions/admin.kt
@@ -67,7 +67,12 @@ val listTopics = zoeFunction<AdminConfig, ListTopicsResponse>(name = "topics") {
 val createTopic = zoeFunction<CreateTopicRequest, CreateTopicResponse>(name = "createTopic") { config ->
     admin(config.props).use { cli ->
         cli
-            .createTopics(listOf(NewTopic(config.name, config.partitions, config.replicationFactor.toShort())))
+            .createTopics(
+                listOf(
+                    NewTopic(config.name, config.partitions, config.replicationFactor.toShort())
+                        .apply { config.topicConfig?.takeIf { it.isNotEmpty() }?.let(this::configs) }
+                )
+            )
             .all()
             .get()
 
@@ -416,6 +421,7 @@ data class CreateTopicRequest(
     val name: String,
     val partitions: Int,
     val replicationFactor: Int,
+    val topicConfig: Map<String, String>?,
     val props: Map<String, String>
 )
 

--- a/zoe-service/src/service.kt
+++ b/zoe-service/src/service.kt
@@ -244,7 +244,8 @@ class ZoeService(
         cluster: String,
         topic: TopicAliasOrRealName,
         partitions: Int,
-        replicationFactor: Int
+        replicationFactor: Int,
+        config: Map<String, String>
     ): CreateTopicResponse {
         val clusterConfig = getCluster(cluster)
         val topicName = clusterConfig.getTopicConfig(topic, subjectOverride = null).name
@@ -253,7 +254,8 @@ class ZoeService(
                 name = topicName,
                 partitions = partitions,
                 replicationFactor = replicationFactor,
-                props = clusterConfig.getCompletedProps()
+                props = clusterConfig.getCompletedProps(),
+                topicConfig = config
             )
         )
     }


### PR DESCRIPTION
This PR adds the ability to inject extra config at topic creation time. Example:

```
zoe topics create my-topic --partitions 5 --replication-factor 1 --config retention.ms=3600
```