### PR TITLE
Add ability to override topics props

### DIFF
--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -38,6 +38,10 @@ clusters:
       topic-alias:
         name: full-name-of-the-topic-in-the-cluster
         subject: subject-name-of-the-topic
+        # Override any kafka client property that is specific to a topic
+        propsOverride:
+          key.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+          value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
 
 # Runners configuration
 runners:

--- a/zoe-cli/src/commands/topics.kt
+++ b/zoe-cli/src/commands/topics.kt
@@ -118,7 +118,7 @@ class TopicsCreate : CliktCommand(
     private val service by inject<ZoeService>()
 
     override fun run() = runBlocking {
-        val response = service.createTopic(ctx.cluster, topic, partitions, replicationFactor, config = topicConfig)
+        val response = service.createTopic(ctx.cluster, topic, partitions, replicationFactor, additionalTopicConfig = topicConfig)
         ctx.term.output.format(response.toJsonNode()) { echo(it) }
     }
 }

--- a/zoe-cli/src/config/config.kt
+++ b/zoe-cli/src/config/config.kt
@@ -41,7 +41,11 @@ data class ClusterConfig(
     val groups: Map<String, String> = mapOf()
 )
 
-data class TopicConfig(val name: String, val subject: String? = null)
+data class TopicConfig(
+    val name: String,
+    val subject: String? = null,
+    val propsOverride: Map<String, String> = emptyMap()
+)
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes(
@@ -74,7 +78,7 @@ sealed class SecretsProviderConfig {
     data class AwsSecretsManager(
         val region: String?,
         val credentials: AwsCredentialsConfig = AwsCredentialsConfig.Default
-    ): SecretsProviderConfig()
+    ) : SecretsProviderConfig()
 }
 
 data class RunnersSection(
@@ -142,7 +146,7 @@ fun AwsCredentialsConfig.resolve(): AWSCredentialsProvider = when (this) {
     is AwsCredentialsConfig.Static -> AWSStaticCredentialsProvider(BasicAWSCredentials(accessKey, secretAccessKey))
 }
 
-fun TopicConfig.toDomain(): Topic = Topic(name = name, subject = subject)
+fun TopicConfig.toDomain(): Topic = Topic(name = name, subject = subject, propsOverride = propsOverride)
 fun ClusterConfig.toDomain(): Cluster = Cluster(
     registry = registry,
     topics = topics.mapValues { it.value.toDomain() },

--- a/zoe-service/src/config/config.kt
+++ b/zoe-service/src/config/config.kt
@@ -39,7 +39,7 @@ data class Cluster(
     val groups: Map<GroupAlias, ConsumerGroup> = mapOf()
 )
 
-data class Topic(val name: String, val subject: String?)
+data class Topic(val name: String, val subject: String?, val propsOverride: Map<String, String>)
 data class ConsumerGroup(val name: String)
 
 typealias TopicAlias = String


### PR DESCRIPTION
This PR adds the ability to override Kafka clients properties at a topic level.

For an example, checkout: https://github.com/adevinta/zoe/pull/10/files#diff-70b92abb2c7fdc4cedea36503ba7c404R41-R44