### PR TITLE
Enhance schema listing

### DIFF
--- a/zoe-cli/src/commands/schemas.kt
+++ b/zoe-cli/src/commands/schemas.kt
@@ -23,12 +23,10 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.optional
-import com.github.ajalt.clikt.parameters.options.default
-import com.github.ajalt.clikt.parameters.options.flag
-import com.github.ajalt.clikt.parameters.options.option
-import com.github.ajalt.clikt.parameters.options.switch
+import com.github.ajalt.clikt.parameters.options.*
 import com.github.ajalt.clikt.parameters.types.choice
 import com.github.ajalt.clikt.parameters.types.file
+import com.github.ajalt.clikt.parameters.types.int
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.koin.core.KoinComponent
@@ -49,8 +47,14 @@ class ListSchemas : CliktCommand(name = "list"), KoinComponent {
     private val ctx by inject<CliContext>()
     private val service by inject<ZoeService>()
 
+    private val filter: Regex?
+        by option("-m", "--matching", help = "Filter only subject names matching the given pattern")
+            .convert { it.toRegex() }
+
+    private val limit: Int? by option("-n", "--limit", help = "Limit the number of returned results").int()
+
     override fun run() = runBlocking {
-        val subjects = service.listSchemas(ctx.cluster).subjects
+        val subjects = service.listSchemas(ctx.cluster, filter, limit).subjects
         ctx.term.output.format(mapOf("subjects" to subjects).toJsonNode()) { echo(it) }
     }
 }

--- a/zoe-cli/src/commands/schemas.kt
+++ b/zoe-cli/src/commands/schemas.kt
@@ -50,7 +50,7 @@ class ListSchemas : CliktCommand(name = "list"), KoinComponent {
     private val service by inject<ZoeService>()
 
     override fun run() = runBlocking {
-        val subjects = service.listSchemas(ctx.cluster).subjects.map { it.subject }
+        val subjects = service.listSchemas(ctx.cluster).subjects
         ctx.term.output.format(mapOf("subjects" to subjects).toJsonNode()) { echo(it) }
     }
 }
@@ -62,10 +62,8 @@ class DescribeSchema : CliktCommand(name = "describe"), KoinComponent {
     private val service by inject<ZoeService>()
 
     override fun run() = runBlocking {
-        val subject = service.listSchemas(ctx.cluster).subjects.find { it.subject == subject }
-            ?: userError("subject not found : $subject")
-
-        ctx.term.output.format(subject.toJsonNode()) { echo(it) }
+        val response = service.describeSchema(ctx.cluster, subject)
+        ctx.term.output.format(response.toJsonNode()) { echo(it) }
     }
 }
 

--- a/zoe-core/src/functions/admin.kt
+++ b/zoe-core/src/functions/admin.kt
@@ -164,19 +164,24 @@ val setOffsets = zoeFunction<SetOffsetRequest, SetOffsetResponse>(name = "setOff
 /**
  * Lambda function to list schemas
  */
-val listSchemas = zoeFunction<ListSchemasConfig, ListSchemasResponse>(name = "schemas") { config ->
+val listSchemas = zoeFunction<ListSchemasConfig, ListSchemasResponse>(name = "listSchemas") { config ->
+    val registry = CachedSchemaRegistryClient(config.registry, 10)
+    ListSchemasResponse(registry.allSubjects.toList())
+}
+
+/**
+ * Lambda function to describe a schema
+ */
+val describeSchema = zoeFunction<DescribeSchemaConfig, DescribeSchemaResponse>(name = "describeSchema") { config ->
     val registry = CachedSchemaRegistryClient(config.registry, 10)
 
-    val subjects = registry.allSubjects.map {
-        SchemaDescription(
-            subject = it,
-            versions = registry.getAllVersions(it),
-            latest = registry.getLatestSchemaMetadata(it).schema
-        )
-    }
-
-    ListSchemasResponse(subjects)
+    DescribeSchemaResponse(
+        subject = config.subject,
+        versions = registry.getAllVersions(config.subject),
+        latest = registry.getLatestSchemaMetadata(config.subject).schema
+    )
 }
+
 
 /**
  * Deploys an avro schema
@@ -324,10 +329,6 @@ data class AdminConfig(
     val props: Map<String, String?> = mapOf()
 )
 
-data class ListSchemasConfig(
-    val registry: String
-)
-
 data class DeploySchemaConfig(
     val registry: String,
     val schema: SchemaContent,
@@ -346,14 +347,23 @@ sealed class DeploySchemaResponse {
         DeploySchemaResponse()
 }
 
-data class SchemaDescription(
+data class DescribeSchemaConfig(
+    val registry: String,
+    val subject: String
+)
+
+data class DescribeSchemaResponse(
     val subject: String,
     val versions: List<Int>,
     val latest: String
 )
 
+data class ListSchemasConfig(
+    val registry: String
+)
+
 data class ListSchemasResponse(
-    val subjects: List<SchemaDescription>
+    val subjects: List<String>
 )
 
 data class TopicDescription(

--- a/zoe-core/src/functions/admin.kt
+++ b/zoe-core/src/functions/admin.kt
@@ -166,7 +166,15 @@ val setOffsets = zoeFunction<SetOffsetRequest, SetOffsetResponse>(name = "setOff
  */
 val listSchemas = zoeFunction<ListSchemasConfig, ListSchemasResponse>(name = "listSchemas") { config ->
     val registry = CachedSchemaRegistryClient(config.registry, 10)
-    ListSchemasResponse(registry.allSubjects.toList())
+    val regex = config.regexFilter?.toRegex()
+    val limit = config.limit
+    val subjects =
+        registry
+            .allSubjects
+            .let { if (regex != null) it.filter { subject -> subject matches regex } else it }
+            .let { if (limit != null) it.take(limit) else it }
+            .toList()
+    ListSchemasResponse(subjects)
 }
 
 /**
@@ -359,7 +367,9 @@ data class DescribeSchemaResponse(
 )
 
 data class ListSchemasConfig(
-    val registry: String
+    val registry: String,
+    val regexFilter: String?,
+    val limit: Int?
 )
 
 data class ListSchemasResponse(

--- a/zoe-core/src/main.kt
+++ b/zoe-core/src/main.kt
@@ -78,6 +78,7 @@ object FunctionsRegistry {
         add(listTopics)
         add(createTopic)
         add(listSchemas)
+        add(describeSchema)
         add(queryOffsets)
         add(listGroups)
         add(deploySchema)

--- a/zoe-service/src/runners/extensions.kt
+++ b/zoe-service/src/runners/extensions.kt
@@ -29,7 +29,7 @@ suspend fun ZoeRunner.poll(config: PollConfig): PollResponse {
 }
 
 suspend fun ZoeRunner.listSchemas(config: ListSchemasConfig): ListSchemasResponse {
-    logger.info("listing schemas...")
+    logger.info("listing schemas ${config.regexFilter?.let { "matching pattern: $it" } ?: ""}")
     return launch(listSchemas.name(), config.toJsonString()).parseJson()
 }
 

--- a/zoe-service/src/runners/extensions.kt
+++ b/zoe-service/src/runners/extensions.kt
@@ -28,9 +28,14 @@ suspend fun ZoeRunner.poll(config: PollConfig): PollResponse {
     return launch(poll.name(), config.toJsonString()).parseJson()
 }
 
-suspend fun ZoeRunner.schemas(config: ListSchemasConfig): ListSchemasResponse {
-    logger.info("requesting schemas...")
+suspend fun ZoeRunner.listSchemas(config: ListSchemasConfig): ListSchemasResponse {
+    logger.info("listing schemas...")
     return launch(listSchemas.name(), config.toJsonString()).parseJson()
+}
+
+suspend fun ZoeRunner.describeSchema(config: DescribeSchemaConfig): DescribeSchemaResponse {
+    logger.info("describing schema: ${config.subject}")
+    return launch(describeSchema.name(), config.toJsonString()).parseJson()
 }
 
 suspend fun ZoeRunner.produce(config: ProduceConfig): ProduceResponse {

--- a/zoe-service/src/service.kt
+++ b/zoe-service/src/service.kt
@@ -196,7 +196,16 @@ class ZoeService(
     suspend fun listSchemas(cluster: String): ListSchemasResponse {
         val clusterConfig = getCluster(cluster)
         requireNotNull(clusterConfig.registry) { "registry must not be null in config to use the listSchemas function" }
-        return runner.schemas(ListSchemasConfig(clusterConfig.registry))
+        return runner.listSchemas(ListSchemasConfig(clusterConfig.registry))
+    }
+
+    /**
+     * Describe schema
+     */
+    suspend fun describeSchema(cluster: String, subject: String): DescribeSchemaResponse {
+        val clusterConfig = getCluster(cluster)
+        requireNotNull(clusterConfig.registry) { "registry must not be null in config to use the listSchemas function" }
+        return runner.describeSchema(DescribeSchemaConfig(registry = clusterConfig.registry, subject = subject))
     }
 
     /**

--- a/zoe-service/src/service.kt
+++ b/zoe-service/src/service.kt
@@ -193,10 +193,10 @@ class ZoeService(
     /**
      * List schemas from the registry
      */
-    suspend fun listSchemas(cluster: String): ListSchemasResponse {
+    suspend fun listSchemas(cluster: String, filter: Regex?, limit: Int?): ListSchemasResponse {
         val clusterConfig = getCluster(cluster)
         requireNotNull(clusterConfig.registry) { "registry must not be null in config to use the listSchemas function" }
-        return runner.listSchemas(ListSchemasConfig(clusterConfig.registry))
+        return runner.listSchemas(ListSchemasConfig(clusterConfig.registry, filter?.toString(), limit))
     }
 
     /**


### PR DESCRIPTION
This PR enhances the schema listing in the following ways:
- It avoids querying each schema when listing subjects. This makes schema listing much faster.
- It adds a `--matching` option to supply a regex to filter the output of the listing.
- It adds a `-n` option to enforce a limit to the output result

Fixes #28  