### PR TITLE
Add schema/subject deletion commands

### DIFF
--- a/docs/advanced/avro.md
+++ b/docs/advanced/avro.md
@@ -4,7 +4,7 @@ Zoe has good support for Avro and the schema registry. It makes it easy to consu
 
 ## Consuming Avro data
 
-In order to consume avro data from Kafka, it is enough to set the necessary deserializers properties in the `props` section of the cluster config :
+In order to consume Avro data from Kafka, it is enough to set the necessary deserializers properties in the `props` section of the cluster config :
 
 ```yaml
 clusters:
@@ -17,7 +17,7 @@ clusters:
       schema.registry.url: http://my-registry.example.com
 ```
 
-Then, it's possible to consume avro data using the following command :
+Then, it's possible to consume Avro data using the following command :
 
 ```bash
 zoe -v -c my-cluster topics consume input -n 10
@@ -32,11 +32,11 @@ With the above command :
 
 To produce Avro data from a json input using the `produce` command, it is necessary to set :
 
-- The `registry` property that points to the schema registry instance. Zoe uses this property to fetch the avro schema needed to transform the json data into avro.
+- The `registry` property that points to the schema registry instance. Zoe uses this property to fetch the Avro schema needed to transform the json data into Avro.
 - The required serializer properties of the producer in the `props` section of the cluster config.
 - In addition, you need to set the `subject` name of the topic in the topic's configuration.
 
-A good enough configuration for producing avro data may look like the following :
+A good enough configuration for producing Avro data may look like the following :
 
 ```yaml
 clusters:
@@ -66,19 +66,20 @@ zoe -v --cluster my-cluster \
 
 The command above would do the following :
 
-- It fetches the avro schema registered under the subject name `long-topic-name-com.adevinta.schemas.v1.Example` in the schema registry instance pointed at by the `registry` property in the configuration.
-- It uses the schema to transform the json data in `data.json` into avro `GenericRecord` instances.
+- It fetches the Avro schema registered under the subject name `long-topic-name-com.adevinta.schemas.v1.Example` in the schema registry instance pointed at by the `registry` property in the configuration.
+- It uses the schema to transform the json data in `data.json` into Avro `GenericRecord` instances.
 - Writes the generic records into `long-name-topic` (aliased by `my-topic`).
 
 ## Interacting with the registry
 
 You can also interact with the schema registry using the `zoe schemas` command. Here is a non exhaustive list  of what you can do :
 
-- List avro schemas registered into the registry
-- Describe a specific Avro schema
-- Deploy an avro schema into the registry from an `.avsc` or `.avdl` file.
+- List avro schemas registered into the registry.
+- Describe a specific Avro schema.
+- Deploy an Avro schema into the registry from an `.avsc` or `.avdl` file.
+- Delete a specific Avro schema or subject from the registry.
 
 ## Where to go from here
 
-- There is a hands on tutorial on using zoe with avro at : [guides/avro](https://github.com/adevinta/zoe/tree/master/docs/guides/avro). 
+- There is a hands on tutorial on using zoe with Avro at : [guides/avro](https://github.com/adevinta/zoe/tree/master/docs/guides/avro). 
 - Learn more about interacting with the registry with : `zoe schemas --help`

--- a/docs/guides/avro/guide.md
+++ b/docs/guides/avro/guide.md
@@ -168,6 +168,36 @@ Describe the schema using:
     └──────────────────────────┴──────────┴─────────────────────────────────────────────────────────────────────────────────────────────┘
     ```
 
+Delete a specific schema version using:
+
+=== "Command"
+
+
+    ```bash
+    zoe schemas delete input-events-topic-value --schema-version 1
+    ```
+
+=== "Output"
+
+    ```text
+    {"type":"actual","response":[1],"subject":"input-events-topic-value","version":"1","hardDelete":"soft delete"}
+    ```
+
+Delete a subject permanently (including metadata):
+
+=== "Command"
+
+
+    ```bash
+    zoe schemas delete input-events-topic-value --hard
+    ```
+
+=== "Output"
+
+    ```text
+    {"type":"actual","response":[2],"subject":"input-events-topic-value","version":"version","hardDelete":"hard delete"} 
+    ```
+
 ## Producing data
 
 Now that we have the Cat Facts Avro schema registered, let's produce some cat facts from the `data.json` file in avro:

--- a/zoe-cli/src/commands/schemas.kt
+++ b/zoe-cli/src/commands/schemas.kt
@@ -71,6 +71,21 @@ class DescribeSchema : CliktCommand(name = "describe"), KoinComponent {
     }
 }
 
+class DeleteSchema : CliktCommand(name = "delete"), KoinComponent {
+    private val subject: String by argument("subject", help = "Subject name to describe")
+    private val schemaVersion: Int? by option("--schema-version", help = "Version of the schema to be deleted").int()
+    private val hardDelete by option("--hard", help = "A hard delete removes all metadata, including schema IDs. Defaulting to soft").flag(default = false)
+    private val dryRun by option("--dry-run", help = "Do not actually create the schema").flag(default = false)
+
+    private val ctx by inject<CliContext>()
+    private val service by inject<ZoeService>()
+
+    override fun run() = runBlocking {
+        val response = service.deleteSchema(ctx.cluster, subject, schemaVersion, hardDelete, dryRun)
+        ctx.term.output.format(response.toJsonNode()) { echo(it) }
+    }
+}
+
 class DeploySchema : CliktCommand(
     name = "deploy",
     help = """Deploy a schema to the registry""",
@@ -164,5 +179,6 @@ class DeploySchema : CliktCommand(
 fun schemasCommand() = SchemasCommand().subcommands(
     ListSchemas(),
     DescribeSchema(),
-    DeploySchema()
+    DeploySchema(),
+    DeleteSchema()
 )

--- a/zoe-cli/test/com/adevinta/oss/zoe/cli/helpers.kt
+++ b/zoe-cli/test/com/adevinta/oss/zoe/cli/helpers.kt
@@ -33,6 +33,7 @@ data class ZoeOutput(val stdout: JsonNode?, val stderr: List<String>, val error:
 suspend fun ExpectScope.zoe(
     vararg command: String,
     configDir: String = testConfDir.resolve("config").absolutePath,
+    shouldFail: Boolean = false,
     expect: suspend TestContext.(ZoeOutput) -> Unit = {}
 ): ZoeOutput {
     val mockConsole = MockConsole()
@@ -63,7 +64,9 @@ suspend fun ExpectScope.zoe(
     }
 
     expect("command '$fullCommand' should return correct result") {
-        res.error shouldBe null
+        if (!shouldFail) {
+            res.error shouldBe null
+        }
         expect(res)
     }
 

--- a/zoe-cli/testResources/env/schema-v2.avdl
+++ b/zoe-cli/testResources/env/schema-v2.avdl
@@ -1,0 +1,20 @@
+@namespace("com.adevinta.oss.zoe.guides")
+protocol ZoeExamples {
+
+  record UserName {
+    string first;
+    string last;
+  }
+
+  record User {
+    string _id;
+    UserName name;
+  }
+
+  record CatFact {
+    string _id;
+    string text;
+    string type;
+    User user;
+  }
+}

--- a/zoe-core/src/main.kt
+++ b/zoe-core/src/main.kt
@@ -83,6 +83,7 @@ object FunctionsRegistry {
         add(queryOffsets)
         add(listGroups)
         add(deploySchema)
+        add(deleteSchema)
         add(offsets)
         add(poll)
         add(produce)

--- a/zoe-service/src/runners/extensions.kt
+++ b/zoe-service/src/runners/extensions.kt
@@ -68,9 +68,12 @@ suspend fun ZoeRunner.setOffsets(config: SetOffsetRequest): SetOffsetResponse {
     return launch(setOffsets.name(), config.toJsonString()).parseJson()
 }
 
-
 suspend fun ZoeRunner.deploySchema(config: DeploySchemaConfig): DeploySchemaResponse {
     return launch(deploySchema.name(), config.toJsonString()).parseJson()
+}
+
+suspend fun ZoeRunner.deleteSchema(config: DeleteSchemaConfig): DeleteSchemaResponse {
+    return launch(deleteSchema.name(), config.toJsonString()).parseJson()
 }
 
 suspend fun ZoeRunner.version(config: VersionCheckRequest): VersionCheckResponse {

--- a/zoe-service/src/service.kt
+++ b/zoe-service/src/service.kt
@@ -244,6 +244,28 @@ class ZoeService(
     }
 
     /**
+     * Deletes an Avro schema or subject (all versions) from the registry
+     */
+    suspend fun deleteSchema(
+        cluster: String,
+        subject: String,
+        schemaVersion: Int?,
+        hardDelete: Boolean,
+        dryRun: Boolean
+    ): DeleteSchemaResponse = with(getCluster(cluster)) {
+        runner.deleteSchema(
+            DeleteSchemaConfig(
+                registry = registry ?: userError("'registry' must not be null in config to deploy schemas"),
+                props = getCompletedProps(null),
+                subject = subject,
+                schemaVersion = schemaVersion,
+                hardDelete = hardDelete,
+                dryRun = dryRun
+            )
+        )
+    }
+
+    /**
      * List topics in the cluster
      */
     suspend fun listTopics(cluster: String, filter: Regex?, userTopicsOnly: Boolean, limit: Int?): ListTopicsResponse {


### PR DESCRIPTION
This PR aims to add the following capabilities to the CLI:
- Delete a specific version of a schema
- Delete a subject
- [Soft](https://docs.confluent.io/platform/current/schema-registry/schema-deletion-guidelines.html#soft-delete-a-schema) & [hard](https://docs.confluent.io/platform/current/schema-registry/schema-deletion-guidelines.html#hard-delete-a-schema) deletes (i.e metadata including schema IDs)

Some docs were added in the related guide.