### PR TITLE
IAM support for Amazon Managed Streaming for Kafka (MSK)

### DIFF
--- a/zoe-cli/build.gradle.kts
+++ b/zoe-cli/build.gradle.kts
@@ -196,7 +196,7 @@ dependencies {
     implementation("org.eclipse.jgit:org.eclipse.jgit:5.7.0.202003110725-r")
 
     implementation("org.apache.commons:commons-text:1.9")
-    implementation("org.koin:koin-core:2.0.1")
+    implementation("io.insert-koin:koin-core:2.0.1")
     implementation("com.jakewharton.picnic:picnic:0.3.1")
     implementation("com.github.ajalt:clikt:2.8.0")
     implementation("com.github.ajalt:mordant:1.2.1")

--- a/zoe-service/build.gradle.kts
+++ b/zoe-service/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation("software.amazon.awssdk:lambda")
     implementation("software.amazon.awssdk:s3")
     implementation("software.amazon.awssdk:secretsmanager")
+    implementation("software.amazon.msk:aws-msk-iam-auth:2.2.0")
 
     implementation("org.slf4j:slf4j-log4j12:1.7.30")
     implementation("log4j:log4j:1.2.17")


### PR DESCRIPTION
Amazon Managed Streaming for Kafka service (MSK) allows a new simple authentication and security layer (SASL) mechanism called **AWS_MSK_IAM**: https://docs.aws.amazon.com/msk/latest/developerguide/iam-access-control.html

In order to enable support, we simply need as dependency the related library for IAM authentication. 
This should allow configuring Kafka properties to bind the related SASL client implementation:

```properties
# Sets up TLS for encryption and SASL for authN.
security.protocol = SASL_SSL

# Identifies the SASL mechanism to use.
sasl.mechanism = AWS_MSK_IAM

# Binds SASL client implementation.
sasl.jaas.config = software.amazon.msk.auth.iam.IAMLoginModule required;

# Encapsulates constructing a SigV4 signature based on extracted credentials.
# The SASL client bound by "sasl.jaas.config" invokes this class.
sasl.client.callback.handler.class = software.amazon.msk.auth.iam.IAMClientCallbackHandler
```

For more, see https://github.com/aws/aws-msk-iam-auth