### PR TITLE
Custom pod annotations for Kubernetes runner

### DIFF
--- a/docs/advanced/runners/kubernetes.md
+++ b/docs/advanced/runners/kubernetes.md
@@ -23,4 +23,8 @@ runners:
       memory: "512M"
       # Timeout for the client operations.
       timeoutMs: 300000
+      # Annotations to attach to the pods. Optional: By default, empty
+      annotations:
+        key1: value1
+        key2: value2
 ```

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -66,6 +66,10 @@ runners:
       memory: "512M"
       # Timeout of the commands
       timeoutMs: 300000
+      # Annotations to attach to the pods 
+      annotations:
+        key1: value1
+        key2: value2
 
     # The lambda runner configuration
     lambda:

--- a/zoe-cli/src/commands/main.kt
+++ b/zoe-cli/src/commands/main.kt
@@ -235,7 +235,8 @@ fun mainModule(context: CliContext) = module {
                         cpu = kubeConfig.cpu,
                         memory = kubeConfig.memory,
                         deletePodsAfterCompletion = kubeConfig.deletePodAfterCompletion,
-                        timeoutMs = kubeConfig.timeoutMs
+                        timeoutMs = kubeConfig.timeoutMs,
+                        annotations = kubeConfig.annotations,
                     ),
                     executor = ioPool,
                     namespace = kubeConfig.namespace,

--- a/zoe-cli/src/config/config.kt
+++ b/zoe-cli/src/config/config.kt
@@ -119,7 +119,8 @@ data class KubernetesRunnerConfig(
     val cpu: String = "1",
     val memory: String = "512M",
     val timeoutMs: Long = 300000,
-    val image: DockerImageConfig = DockerImageConfig()
+    val image: DockerImageConfig = DockerImageConfig(),
+    val annotations: Map<String, String> = emptyMap(),
 )
 
 data class DockerImageConfig(

--- a/zoe-core/build.gradle.kts
+++ b/zoe-core/build.gradle.kts
@@ -28,6 +28,7 @@ jib {
 
 dependencies {
     implementation("com.amazonaws:aws-lambda-java-core:1.2.1")
+    implementation("software.amazon.msk:aws-msk-iam-auth:2.2.0")
 
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.11.0")
     implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/zoe-service/build.gradle.kts
+++ b/zoe-service/build.gradle.kts
@@ -16,7 +16,6 @@ dependencies {
     implementation("software.amazon.awssdk:lambda")
     implementation("software.amazon.awssdk:s3")
     implementation("software.amazon.awssdk:secretsmanager")
-    implementation("software.amazon.msk:aws-msk-iam-auth:2.2.0")
 
     implementation("org.slf4j:slf4j-log4j12:1.7.30")
     implementation("log4j:log4j:1.2.17")


### PR DESCRIPTION
Allow conditional definition of custom annotations for the pod created by the [Kubernetes runner](https://adevinta.github.io/zoe/advanced/runners/kubernetes/) such as:

```yaml
  # Runner configuration
  config:
    # The kubernetes runner configuration
    kubernetes:
      # Kubernetes context to use
      context: mu-kube-context
      # Namespace to use
      namespace: env-staging
      # Annotations to attach to the pods 
      annotations:
        key1: value1
        key2: value2
```

This follows work around allows a new simple authentication and security layer (SASL) mechanism called [AWS_MSK_IAM](https://docs.aws.amazon.com/msk/latest/developerguide/iam-access-control.html) for the Amazon MSK service (see https://github.com/adevinta/zoe/pull/56).
In some cases, it can notably be useful to define annotations in order to be able to assume IAM roles within Kubernetes, authorizing interaction with resources living in MSK. 