### PR TITLE
fix(lambda): custom describe deserialization

### DIFF
--- a/zoe-cli/src/commands/lambda.kt
+++ b/zoe-cli/src/commands/lambda.kt
@@ -19,6 +19,7 @@ import com.adevinta.oss.zoe.core.Handler
 import com.adevinta.oss.zoe.core.utils.buildJson
 import com.adevinta.oss.zoe.core.utils.logger
 import com.adevinta.oss.zoe.core.utils.toJsonNode
+import com.adevinta.oss.zoe.core.utils.toJsonString
 import com.adevinta.oss.zoe.service.runners.LambdaZoeRunner
 import com.adevinta.oss.zoe.service.utils.lambdaClient
 import com.adevinta.oss.zoe.service.utils.userError
@@ -78,7 +79,7 @@ class DescribeLambda : CliktCommand(name = "describe", help = "Describe the curr
         val response =
             lambda
                 .getFunctionOrNull(name)
-                ?.toJsonNode()
+                ?.asJson()
                 ?: userError("lambda function not found: $name")
 
         ctx.term.output.format(response) { echo(it) }
@@ -251,6 +252,13 @@ fun SdkPojo.asJson(): JsonNode = buildJson {
         val value = field.getValueOrDefault(this@asJson)
         set<JsonNode>(field.memberName(), if (value is SdkPojo) value.asJson() else TextNode("$value"))
     }
+}
+
+fun LambdaDescription.asJson(): JsonNode = buildJson {
+    set<JsonNode>("current", configuration.asJson())
+    set<JsonNode>("code", code.asJson())
+    set<JsonNode>("concurrency", concurrency?.toJsonNode())
+    set<JsonNode>("tags", tags.map { it.toJsonString() }.toJsonNode())
 }
 
 fun StackCreationResult.asJson() = buildJson {


### PR DESCRIPTION
The naive deserialization was causing issues on some custom nullable fields within certain sdk objects such as the lambda configuration object:

```error: No serializer found for class software.amazon.awssdk.services.lambda.model.FunctionConfiguration and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS) (through reference chain: com.adevinta.oss.zoe.cli.commands.LambdaDescription["configuration"])```