### PR TITLE
fix(ci): rpm package dependencies

### DIFF
--- a/.github/workflows/upload-release-assets.yml
+++ b/.github/workflows/upload-release-assets.yml
@@ -184,6 +184,13 @@ jobs:
           java-package: jdk
           architecture: x64
 
+      - name: Setup rpm dependencies
+        id: dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y fakeroot
+          sudo apt-get install -y rpm
+
       - name: Package
         id: package
         run: |


### PR DESCRIPTION
This PR aims at fixing the `.rpm` and `.deb` packaging broken on release process, later use for package install: https://adevinta.github.io/zoe/install/package/

Set up:
- Missing [fakeroot](https://wiki.debian.org/FakeRoot) needed for `.deb` packaging by jpackage
- Missing `rpm` libraries, missing by default on Ubuntu and needed for `.rpm` packaging by jpackage.

